### PR TITLE
PRO-969 - Auto Refresh Bug Fix

### DIFF
--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -267,11 +267,6 @@ const SignIn = ({ onWeb3ProviderSet, onWeb3AuthInstanceSet }: SignInProps) => {
         setIsSigningIn(false);
       });
 
-      web3AuthInstance.on(ADAPTER_EVENTS.DISCONNECTED, () => {
-        // onWeb3ProviderSet(null);
-        // setIsSigningIn(false);
-      });
-
       web3AuthInstance.on(ADAPTER_EVENTS.ERRORED, () => {
         setIsSigningIn(false);
       });

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -268,8 +268,8 @@ const SignIn = ({ onWeb3ProviderSet, onWeb3AuthInstanceSet }: SignInProps) => {
       });
 
       web3AuthInstance.on(ADAPTER_EVENTS.DISCONNECTED, () => {
-        onWeb3ProviderSet(null);
-        setIsSigningIn(false);
+        // onWeb3ProviderSet(null);
+        // setIsSigningIn(false);
       });
 
       web3AuthInstance.on(ADAPTER_EVENTS.ERRORED, () => {


### PR DESCRIPTION
Manually switching chains on MetaMask resets the entire app since in MetaMask when chain is switched it first disconnects and connects back to the chain switched and adapter event triggers disconnect code bit which makes the provider as null. So removed the code bit which makes it null thus enabling the app to switch chains without auto refreshing the whole UX

https://user-images.githubusercontent.com/82584664/211509021-ea5015fd-984a-4a6a-bd0c-2b3be7ab2e15.mov

