### PR TITLE
Implement API token auth for CF Pages GH Action

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -5,12 +5,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Send Slack deployment notifications
-      uses: arddluma/cloudflare-pages-slack-notification@v2.3
+      uses: arddluma/cloudflare-pages-slack-notification@v3
       with:
-        accountEmail: ${{ secrets.CF_ACCOUNT_EMAIL  }}
-        apiKey: ${{ secrets.CF_API_KEY  }}
+        apiToken: ${{ secrets.CF_API_TOKEN }}
         accountId: ${{ secrets.CF_ACC_ID  }}
         project: ${{ secrets.CF_PROJECT  }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated `actions/checkout` to v3
Updated `arddluma/cloudflare-pages-slack-notification` to v3, implemented API token auth instead of Acc email / Global API key
