### PR TITLE
PRO-1111: Inconsistent Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Etherspot, TRANSACTION_BLOCK_TYPE } from '@etherspot/react-transaction-buidler';
+import { Etherspot } from '@etherspot/react-transaction-buidler';
 import styled, { createGlobalStyle } from 'styled-components';
 import Web3 from 'web3';
 import { Web3AuthCore } from '@web3auth/core';
@@ -14,7 +14,7 @@ import SignIn from './components/SignIn';
 
 const { chains, provider, webSocketProvider } = configureChains(
   [mainnet],
-  [infuraProvider({ apiKey: process.env.REACT_APP_INFURA_ID ?? '' }), publicProvider()],
+  [infuraProvider({ apiKey: process.env.REACT_APP_INFURA_ID ?? '' }), publicProvider()]
 );
 
 const client = createClient({
@@ -37,7 +37,6 @@ const client = createClient({
   provider,
   webSocketProvider,
 });
-
 
 const chainId = 1;
 
@@ -170,7 +169,7 @@ const App = () => {
 
               const web3 = new Web3(web3Provider as any);
               // @ts-ignore
-              setConnectedProvider(isWagmi ? web3.currentProvider.provider : web3.currentProvider)
+              setConnectedProvider(isWagmi ? web3.currentProvider.provider : web3.currentProvider);
             }}
             onWeb3AuthInstanceSet={setWeb3AuthInstance}
             setWagmiLogout={setWagmiLogout}
@@ -180,7 +179,6 @@ const App = () => {
           <div>
             <ToggleThemeButton onClick={() => setUseDashboardTheme(!useDashboardTheme)}>Toggle theme</ToggleThemeButton>
             <Etherspot
-              defaultTransactionBlocks={[{ type: TRANSACTION_BLOCK_TYPE.ASSET_BRIDGE }]}
               provider={connectedProvider}
               chainId={chainId}
               themeOverride={themeOverride}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,5 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);


### PR DESCRIPTION
https://linear.app/pillarproject/issue/PRO-1111/etherspot-services-inconsistent-results

The dApp was instantiating twice, meaning we were making twice the amount of requests per load - which means we kept hitting the rates limiter from Etherspot. This seemed to happen because of React.StrictMode, which I've removed for now. 

It's usually better to keep this for debugging reasons, but I figured it should be fine considering the heavy lifting is done in the Buidler component.